### PR TITLE
[FIX] Convert niche filter to array

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "influence_hub",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "influence_hub",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@nestjs/common": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "influence_hub",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "api to manage brands and influencers",
   "author": "Rafael Ribeiro",
   "private": true,

--- a/src/modules/influencer/interfaces/influencer.interface.ts
+++ b/src/modules/influencer/interfaces/influencer.interface.ts
@@ -59,6 +59,6 @@ export interface IUpdateInfluencer {
 export interface IInfluencerFilters {
   reachMin?: string;
   reachMax?: string;
-  niche?: string;
+  niche?: string[];
   city?: string;
 }

--- a/src/modules/influencer/repository/influencer.repository.ts
+++ b/src/modules/influencer/repository/influencer.repository.ts
@@ -105,7 +105,11 @@ export class InfluencerRepository implements IInfluencerRepository<Influencer> {
               ? {
                   Niche: {
                     some: {
-                      niche: { name: niche },
+                      niche: {
+                        name: {
+                          in: niche,
+                        },
+                      },
                     },
                   },
                 }

--- a/src/modules/influencer/services/find-influencers-by-filter.service.ts
+++ b/src/modules/influencer/services/find-influencers-by-filter.service.ts
@@ -38,6 +38,12 @@ export class InfluencersByFilterService {
 
   async execute(filters: IInfluencerFilters): Promise<IInfluencerDetails[]> {
     try {
+      if (filters.niche && typeof filters.niche === 'string') {
+        filters.niche = (filters.niche as string)
+          .split(',')
+          .map((niche) => niche.trim());
+      }
+
       const influencersData =
         await this.influencerRepository.findInfluencerByFilter(filters);
 


### PR DESCRIPTION
issue: find influencer by niche was only possible with one niche, but niche can be a array.

solution: convert niche to array.